### PR TITLE
Revert to original `blank` template `contents` key

### DIFF
--- a/templates/blank.tmpl
+++ b/templates/blank.tmpl
@@ -1,1 +1,1 @@
-{{.Content}}
+{{.contents}}


### PR DESCRIPTION
The cyverse-de/iplant-email repo's `blank` template used `contents`:
https://github.com/cyverse-de/iplant-email/blob/c6417d552b6937212ec0f5cc8e0c759ee810624d/conf/blank.st#L1

At least the `permanent-id-requests` endpoints in cyverse-de/terrain still attempt to send notification status update emails with the `blank` template using the `contents` key:
https://github.com/cyverse-de/terrain/blob/43f19d3e8de367edcbddc286b90e136ceb53b1eb/src/terrain/services/permanent_id_requests.clj#L301

Changing the `blank` template `contents` key to `Content` is causing DOI status update emails to omit the update comments in users' notification emails, which means they no longer receive the final DOI in the request completion email.