### PR TITLE
core-1495 Format email to intercom support as plain text.

### DIFF
--- a/api.go
+++ b/api.go
@@ -52,7 +52,13 @@ func (a *API) EmailRequestHandler(w http.ResponseWriter, r *http.Request) {
 			} else {
 				toAddr := emailReq.To
 				logcabin.Info.Println("Emailing " + toAddr + " host:" + a.emailClient.smtpHost)
-				err := a.emailClient.Send([]string{toAddr}, emailReq.Subject, formattedMsg.String())
+				var mimeType string
+				if emailReq.Template == "blank" {
+					mimeType = TEXT_MIME_TYPE
+				} else {
+					mimeType = HTML_MIME_TYPE
+				}
+				err := a.emailClient.Send([]string{toAddr}, mimeType, emailReq.Subject, formattedMsg.String())
 				if err != nil {
 					logcabin.Error.Println("failed to send email to " + toAddr + " host:" + a.emailClient.smtpHost)
 				}

--- a/email.go
+++ b/email.go
@@ -6,6 +6,9 @@ import (
 	"github.com/cyverse-de/logcabin"
 )
 
+const HTML_MIME_TYPE = "text/html"
+const TEXT_MIME_TYPE = "text/plain"
+
 // EmailClient is a client used to send email messages to an SMTP server.
 type EmailClient struct {
 	smtpHost    string
@@ -31,14 +34,14 @@ type Email struct {
 	body    string
 }
 
-func (r *EmailClient) Send(to []string, subject, body string) error {
+func (r *EmailClient) Send(to []string, mimeType, subject, body string) error {
 
 	m := gomail.NewMessage()
 	m.SetHeader("From", r.fromAddress)
 	m.SetHeader("mailed-by", "cyverse.org")
 	m.SetHeader("To", to[0])
 	m.SetHeader("Subject", subject)
-	m.SetBody("text/html", body)
+	m.SetBody(mimeType, body)
 
 	d := gomail.Dialer{Host: r.smtpHost, Port: r.smtpPort}
 


### PR DESCRIPTION
For on-going intercom issue, I have this quick fix. 
I also created - https://cyverse.atlassian.net/jira/software/projects/CORE/issues/CORE-1496 to support text formatted emails for all the templates.