### PR TITLE
CORE-1554 Add permanent_id_request_completion_user template

### DIFF
--- a/formatMessage.go
+++ b/formatMessage.go
@@ -71,6 +71,7 @@ func FormatMessage(emailReq EmailRequest, payload map[string](interface{}), deSe
 	var template_output bytes.Buffer
 
 	payload["DELink"] = deSettings.base
+	payload["DEDataLink"] = deSettings.base + deSettings.data
 	payload["DETeamsLink"] = deSettings.base + deSettings.teams
 	payload["DEAdminDoiRequestLink"] = deSettings.base + deSettings.admin + deSettings.doi
 	payload["DEToolsLink"] = deSettings.base + deSettings.tools

--- a/templates/html/permanent_id_request.tmpl
+++ b/templates/html/permanent_id_request.tmpl
@@ -1,6 +1,6 @@
 <p>Dear Curator,</p>
 
-<p>We are notifying you that {{.user}} has requested a new
+<p>We are notifying you that {{.user}} ({{.username}}) has requested a new
 <a href="{{.DEAdminDoiRequestLink}}" target="_blank" rel="noopener noreferrer">{{.request_type}}</a>
 Permanent ID for the
 <a href="{{.DEDataLink}}{{.path}}" target="_blank" rel="noopener noreferrer">{{.path}}</a>

--- a/templates/html/permanent_id_request.tmpl
+++ b/templates/html/permanent_id_request.tmpl
@@ -1,6 +1,7 @@
 <p>Dear Curator,</p>
 
-<p>We are notifying you that {{.user}} has requested a new <a href="{{.DEPidRequestLink}}" target="_blank">{{.request_type}}</a> Permanent ID for the
-{{.path}} dataset in the {{.environment}} environment.</p>
-
-{{ template "footer" . }}
+<p>We are notifying you that {{.user}} has requested a new
+<a href="{{.DEAdminDoiRequestLink}}" target="_blank" rel="noopener noreferrer">{{.request_type}}</a>
+Permanent ID for the
+{{.path}}
+dataset in the {{.environment}} environment.</p>

--- a/templates/html/permanent_id_request.tmpl
+++ b/templates/html/permanent_id_request.tmpl
@@ -3,5 +3,5 @@
 <p>We are notifying you that {{.user}} has requested a new
 <a href="{{.DEAdminDoiRequestLink}}" target="_blank" rel="noopener noreferrer">{{.request_type}}</a>
 Permanent ID for the
-{{.path}}
+<a href="{{.DEDataLink}}{{.path}}" target="_blank" rel="noopener noreferrer">{{.path}}</a>
 dataset in the {{.environment}} environment.</p>

--- a/templates/html/permanent_id_request_complete.tmpl
+++ b/templates/html/permanent_id_request_complete.tmpl
@@ -1,7 +1,7 @@
 <p>Dear Curator,</p>
 
 <p>The {{.request_type}} Permanent ID has been created for the
-{{.path}}
+<a href="{{.DEDataLink}}{{.path}}" target="_blank" rel="noopener noreferrer">{{.path}}</a>.</p>
 dataset, which has been published in the {{.environment}} environment.</p>
 
 <p>The dataset is available via its landing page at

--- a/templates/html/permanent_id_request_complete.tmpl
+++ b/templates/html/permanent_id_request_complete.tmpl
@@ -1,9 +1,13 @@
-
 <p>Dear Curator,</p>
+
 <p>The {{.request_type}} Permanent ID has been created for the
 {{.path}}
 dataset, which has been published in the {{.environment}} environment.</p>
-<p>The identifier(s) created is:</p>
-{{.identifiers}}
 
-<p>The dataset is available via its landing page at <a link="https://doi.org/{{.doi}}" target="_blank">DOI</a>.</p>
+<p>The dataset is available via its landing page at
+<a href="https://doi.org/{{.doi}}" target="_blank" rel="noopener noreferrer">https://doi.org/{{.doi}}</a>.</p>
+
+<p>The DataCite API response:</p>
+<pre>
+{{.api_response}}
+</pre>

--- a/templates/html/permanent_id_request_completion_user.tmpl
+++ b/templates/html/permanent_id_request_completion_user.tmpl
@@ -1,6 +1,7 @@
 {{ template "header" . }}
 
-<p>The DOI Permanent ID has been created for {{.path}}</p>
+<p>The DOI Permanent ID has been created for
+<a href="{{.DEDataLink}}{{.path}}" target="_blank" rel="noopener noreferrer">{{.path}}</a></p>
 
 <p>The dataset is available via its landing page at
 <a href="https://doi.org/{{.doi}}" target="_blank" rel="noopener noreferrer">https://doi.org/{{.doi}}</a>.</p>

--- a/templates/html/permanent_id_request_completion_user.tmpl
+++ b/templates/html/permanent_id_request_completion_user.tmpl
@@ -1,0 +1,15 @@
+{{ template "header" . }}
+
+<p>The DOI Permanent ID has been created for {{.path}}</p>
+
+<p>The dataset is available via its landing page at
+<a href="https://doi.org/{{.doi}}" target="_blank" rel="noopener noreferrer">https://doi.org/{{.doi}}</a>.</p>
+
+<p>Your dataset is now available to CyVerse users and the public.
+If you need to make any changes to the dataset, including the metadata,
+please contact doi@cyverse.org.</p>
+
+<p>If this dataset accompanies a paper,
+please contact us with the DOI for that paper once it is published.</p>
+
+{{ template "footer" . }}

--- a/templates/html/permanent_id_request_move_error.tmpl
+++ b/templates/html/permanent_id_request_move_error.tmpl
@@ -1,7 +1,0 @@
-<p>Dear Curator,</p>
-<p>{{.path}} could not be moved to the {{.dest}} folder as requested by {{.user}} in the {{.environment}} environment.</p>
-
-<p>Here is the auto-generated error message:</p>
-{{.error_message}}
-
-<p>This data will need to be manually moved to the desired location.</p>

--- a/templates/html/permanent_id_request_move_error.tmpl
+++ b/templates/html/permanent_id_request_move_error.tmpl
@@ -1,0 +1,15 @@
+<p>Dear Curator,</p>
+
+<p>
+<a href="{{.DEDataLink}}{{.path}}" target="_blank" rel="noopener noreferrer">{{.path}}</a>
+could not be moved to the
+<a href="{{.DEDataLink}}{{.dest}}" target="_blank" rel="noopener noreferrer">{{.dest}}</a>
+folder as requested by {{.user}} in the {{.environment}} environment.
+</p>
+
+<p>Here is the auto-generated error message:</p>
+<pre>
+{{.error_message}}
+</pre>
+
+<p>This data may need to be manually moved to the desired location.</p>

--- a/templates/html/permanent_id_request_move_error.tmpl
+++ b/templates/html/permanent_id_request_move_error.tmpl
@@ -4,7 +4,7 @@
 <a href="{{.DEDataLink}}{{.path}}" target="_blank" rel="noopener noreferrer">{{.path}}</a>
 could not be moved to the
 <a href="{{.DEDataLink}}{{.dest}}" target="_blank" rel="noopener noreferrer">{{.dest}}</a>
-folder as requested by {{.user}} in the {{.environment}} environment.
+folder as requested by {{.user}} ({{.username}}) in the {{.environment}} environment.
 </p>
 
 <p>Here is the auto-generated error message:</p>

--- a/templates/html/permanent_id_request_submitted.tmpl
+++ b/templates/html/permanent_id_request_submitted.tmpl
@@ -2,7 +2,9 @@
 
 <p>Your {{.request_type}} Permanent ID Request was successfully submitted.</p>
 
-<p>Your data set has been moved to {{.path}} for administrative review.</p>
+<p>Your data set has been moved to
+<a href="{{.DEDataLink}}{{.path}}" target="_blank" rel="noopener noreferrer">{{.path}}</a>
+for administrative review.</p>
 
 <p>You will receive notifications in the
 <a href="{{.DELink}}" target="_blank" rel="noopener noreferrer">Discovery Environment</a>

--- a/templates/html/permanent_id_request_submitted.tmpl
+++ b/templates/html/permanent_id_request_submitted.tmpl
@@ -1,9 +1,11 @@
 {{ template "header" . }}
 
 <p>Your {{.request_type}} Permanent ID Request was successfully submitted.</p>
+
 <p>Your data set has been moved to {{.path}} for administrative review.</p>
-<p>You will receive notifications in the <a href="{{.DELink}}" target="_blank">Discovery Environment</a> as the request process proceeds.</p>
+
+<p>You will receive notifications in the
+<a href="{{.DELink}}" target="_blank" rel="noopener noreferrer">Discovery Environment</a>
+as the request process proceeds.</p>
 
 {{ template "footer" . }}
-
-

--- a/templates/text/permanent_id_request_move_error.tmpl
+++ b/templates/text/permanent_id_request_move_error.tmpl
@@ -1,8 +1,0 @@
-Dear Curator,
-
-{{.path}} could not be moved to the {{.dest}} folder as requested by {{.user}} in the {{.environment}} environment.
-
-Here is the auto-generated error message:
-{{.error_message}}
-
-This data may need to be manually moved to the desired location.

--- a/templates/text/permanent_id_request_move_error.tmpl
+++ b/templates/text/permanent_id_request_move_error.tmpl
@@ -1,0 +1,8 @@
+Dear Curator,
+
+{{.path}} could not be moved to the {{.dest}} folder as requested by {{.user}} in the {{.environment}} environment.
+
+Here is the auto-generated error message:
+{{.error_message}}
+
+This data may need to be manually moved to the desired location.


### PR DESCRIPTION
This PR will add a `permanent_id_request_completion_user` template, and the following additional `permanent_id_request` template updates:

* Update admin/curator completion email, renaming the template key `identifiers` to `api_response`, and displaying the DataCite API response at the end of the message, since it can be a long block of JSON.
* Add `rel="noopener noreferrer"` attributes to `target="_blank"` links.
* Wrap folder paths in links to those folders in the DE.
* Include the requesting user's username in new and data-move-error emails.
* Wrap the error message in data-move-error emails in a `pre` tag to preserve formatting (in case of multi-line error messages).