### PR TITLE
Set the LocalName/HELO to something more specific, hopefully reducing…

### DIFF
--- a/email.go
+++ b/email.go
@@ -46,7 +46,7 @@ func (r *EmailClient) Send(to []string, mimeType, subject, body string) error {
 		m.SetBody(mimeType, body)
 	}
 
-	d := gomail.Dialer{Host: r.smtpHost, Port: r.smtpPort}
+	d := gomail.Dialer{Host: r.smtpHost, Port: r.smtpPort, LocalName: "de-mailer"}
 
 	if err := d.DialAndSend(m); err != nil {
 		logcabin.Error.Println(err)


### PR DESCRIPTION
… spamminess scores via the HELO_LOCALHOST spamassassin rule (and similar)

I _think_ this is all we need to do to improve on the HELO_LOCALHOST issue, based in part on the (PHP-specific) fix in https://issues.civicrm.org/jira/browse/CRM-3153