### PR TITLE
CORE-2086: Subscription Portal support.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Build and Test
+```bash
+# Build the service
+go build .
+
+# Run tests (if any exist)
+go test ./...
+
+# Build Docker image
+docker build -t de-mailer .
+
+# Run golangci-lint (uses GitHub workflow)
+golangci-lint run
+```
+
+### Running the Service
+```bash
+# Run locally (requires config file)
+./de-mailer --config /path/to/config.yml
+
+# Default config path expected at:
+# /etc/iplant/de/emailservice.yml
+```
+
+## Architecture Overview
+
+**de-mailer** is a Go microservice that sends HTML and plain text email notifications for the CyVerse Discovery Environment.
+
+### Core Components
+
+- **main.go**: Entry point, configuration loading, HTTP server setup on port 8080
+- **api.go**: REST API handler for email requests (POST to `/`)
+- **email.go**: SMTP email client implementation using gomail
+- **formatMessage.go**: Template processing for HTML/text emails with DE-specific URL generation
+- **error.go**: Custom HTTP error handling
+
+### Key Design Patterns
+
+1. **Template-based Emails**: Uses Go templates in `/templates/html/` and `/templates/text/` directories
+2. **Configuration**: Uses cyverse-de/configurate for YAML config management
+3. **Observability**: Integrated OpenTelemetry tracing via otelutils
+4. **DE URL Integration**: Builds context-aware URLs for DE components (analyses, data, teams, etc.)
+
+### Email Request Flow
+1. POST request to `/` with EmailRequest JSON payload
+2. Parse template name and values from request
+3. Load appropriate template (HTML or text)
+4. Format message with DE-specific URLs and context
+5. Send via SMTP using configured host
+
+### Configuration Structure
+Required config keys:
+- `email.smtpHost`: SMTP server address
+- `email.fromAddress`: Default sender email
+- `de.base`: Base URL for DE interface
+- `de.data`, `de.analyses`, `de.teams`, etc.: DE component URLs

--- a/api.go
+++ b/api.go
@@ -51,7 +51,7 @@ func (a *API) EmailRequestHandler(w http.ResponseWriter, r *http.Request) {
 			} else {
 				toAddr := emailReq.To
 				log.Infof("Emailing %s host: %s", toAddr, a.emailClient.smtpHost)
-				var mimeType string = TEXT_MIME_TYPE
+				var mimeType = TEXT_MIME_TYPE
 				if isHtml {
 					mimeType = HTML_MIME_TYPE
 				}

--- a/error.go
+++ b/error.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-//copied from https://gitlab.com/sonoran.sarah/cacao/-/blob/master/api-service/utils/error.go#L13-35
+// copied from https://gitlab.com/sonoran.sarah/cacao/-/blob/master/api-service/utils/error.go#L13-35
 // HTTPError is an error that includes an HTTP response code.
 type HTTPError struct {
 	code    int
@@ -25,7 +25,7 @@ func (h *HTTPError) Error() string {
 }
 
 // NewHTTPError returns a new HTTP error with the given status code and (optionally formatted) message.
-func NewHTTPError(code int, format string, args ...interface{}) *HTTPError {
+func NewHTTPError(code int, format string, args ...any) *HTTPError {
 	return &HTTPError{
 		code:    code,
 		message: fmt.Sprintf(format, args...),

--- a/formatMessage.go
+++ b/formatMessage.go
@@ -20,13 +20,15 @@ import (
 type EmailRequest struct {
 	FromAddr string
 	To       string
+	Cc       string
+	Bcc      string
 	Template string
 	Subject  string
 	Values   json.RawMessage
 }
 
 type Templater interface {
-	Execute(io.Writer, interface{}) error
+	Execute(io.Writer, any) error
 }
 
 // VICERequestCompleteDetails contains the request detail fields that we need to extract when a VICE access request is
@@ -55,7 +57,7 @@ type RequestSubmittedDetails struct {
 }
 
 // ExtractDetails extracts fields from a nested object in the payload.
-func ExtractDetails(payload map[string]interface{}, dest interface{}, fieldNames ...string) error {
+func ExtractDetails(payload map[string]any, dest any, fieldNames ...string) error {
 	for _, fieldName := range fieldNames {
 		source, ok := payload[fieldName]
 		if ok && source != nil {
@@ -67,7 +69,7 @@ func ExtractDetails(payload map[string]interface{}, dest interface{}, fieldNames
 }
 
 // format email message using templates
-func FormatMessage(ctx context.Context, emailReq EmailRequest, payload map[string](interface{}), deSettings DESettings) (bytes.Buffer, bool, error) {
+func FormatMessage(ctx context.Context, emailReq EmailRequest, payload map[string](any), deSettings DESettings) (bytes.Buffer, bool, error) {
 	ctx, span := otel.Tracer(otelName).Start(ctx, "FormatMessage")
 	defer span.End()
 
@@ -87,7 +89,7 @@ func FormatMessage(ctx context.Context, emailReq EmailRequest, payload map[strin
 	payload["DEPublicationRequestsLink"] = deSettings.base + deSettings.admin + deSettings.apps
 	payload["DEPidRequestLink"] = deSettings.base + deSettings.admin + deSettings.doi
 
-	var isHtml bool = false
+	var isHtml = false
 	var tmpl Templater
 	var err error
 

--- a/main.go
+++ b/main.go
@@ -80,10 +80,10 @@ func parseCommandLine() *commandLineOptionValues {
 }
 
 // parseRequestBody will parse the post body. The body is the notification message
-func parseRequestBody(r *http.Request) (EmailRequest, map[string](interface{}), error) {
+func parseRequestBody(r *http.Request) (EmailRequest, map[string](any), error) {
 	var emailReq EmailRequest
 	// unmarshall payload to map with interface{}
-	payloadMap := make(map[string](interface{}))
+	payloadMap := make(map[string](any))
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/templates/html/subscription_purchase_admin_required.tmpl
+++ b/templates/html/subscription_purchase_admin_required.tmpl
@@ -1,0 +1,14 @@
+{{ template "header" . }}
+
+<p>A user successfully purchased a subscription at {{.PurchaseTime}}, but the subscription could not be created in
+CyVerse. Please create a subscription for the user and notify them when done.</p>
+
+<table>
+  <tbody>
+    <tr><td>Username</td><td>{{.Username}}</td></tr>
+    <tr><td>Subscription Level</td><td>{{.SubscriptionLevel}}</td></tr>
+    <tr><td>Subscription Periods</td><td>{{.SubscriptionPeriods}}</td></tr>
+  </tbody>
+</table>
+
+{{ template "footer" . }}

--- a/templates/html/subscription_purchase_complete.tmpl
+++ b/templates/html/subscription_purchase_complete.tmpl
@@ -1,0 +1,8 @@
+{{ template "header" . }}
+
+<p>Thank you for purchasing a {{.SubscriptionLevel}} subscription with CyVerse! We greatly appreciate your
+business. Please feel free to contact us at support@cyverse.org if you have any questions or encounter any problems.</p>
+
+<p>Your transaction ID is <strong>{{.TransactionId}}</strong>, your PO number is <strong>{{.PoNumber}}</strong>.</p>
+
+{{ template "footer" . }}


### PR DESCRIPTION
This PR includes the following features:

- New templates for emails sent by the subscription portal.
- ~Support for optional `Cc` and `Bcc` headers.~
- ~Dependency and Go updates.~

I was distracted most of the day troubleshooting an issue that came up, so I wasn't able to finish adding support for the new fields or updating dependencies and switching to a new version of Go. I'll add those features in a subsequent PR. In the meantime, this should be ready for review.
