### PR TITLE
CORE-2070 Update subscription purchase template with additional info

### DIFF
--- a/templates/html/subscription_purchase_complete.tmpl
+++ b/templates/html/subscription_purchase_complete.tmpl
@@ -5,21 +5,22 @@ business. Please feel free to contact us at support@cyverse.org if you have any 
 
 <p>Your transaction ID is <strong>{{.TransactionId}}</strong>, your PO number is <strong>{{.PoNumber}}</strong>.</p>
 
+
+<p>
+    <b>Billed to</b><br />
+    {{.BillToName}}<br />
+    {{.BillToCompany}}<br />
+    {{.BillToAddress}}<br />
+</p>
+
 <p>
     Payed with {{.CardType}} ending in {{.CardNumberEnding}}<br />
     Expires {{.CardExpiration}}
 </p>
 
-<p>
-    Billed to<br />
-    <b>{{.BillToName}}</b><br />
-    {{.BillToCompany}}<br />
-    {{.BillToAddress}}<br />
-</p>
-
 {{if .SubscriptionLevel}}
 <p>Your ordered subscription tier is <b>{{.SubscriptionLevel}}</b> for <b>{{.SubscriptionPeriod}}</b></p>
-<table>
+<table style="text-align: left;">
     <tbody>
         <tr>
             <th>Price</th>
@@ -35,14 +36,12 @@ business. Please feel free to contact us at support@cyverse.org if you have any 
         </tr>
         <tr>
             <th>Quotas</th>
-            <td></td>
+            <td>
+                {{range .SubscriptionQuotas}}
+                    {{.}}<br />
+                {{end}}
+            </td>
         </tr>
-        {{range .SubscriptionQuotas}}
-        <tr>
-            <td></td>
-            <td>{{.}}</td>
-        </tr>
-        {{end}}
     </tbody>
 </table>
 {{- end}}
@@ -50,19 +49,12 @@ business. Please feel free to contact us at support@cyverse.org if you have any 
 {{if .Addons}}
 <p><b>Ordered Add-ons</b></p>
 <table>
-    <thead>
-        <tr>
-            <th>Add-on</th>
-            <th>Quantity</th>
-            <th>Unit Price</th>
-        </tr>
-    </thead>
     <tbody>
         {{range .Addons}}
         <tr>
+            <td>{{.Quantity}}x</td>
             <td>{{.Name}}</td>
-            <td>{{.Quantity}}</td>
-            <td>{{.Price}}</td>
+            <td>&nbsp; {{.Price}}</td>
         </tr>
         {{end}}
     </tbody>

--- a/templates/html/subscription_purchase_complete.tmpl
+++ b/templates/html/subscription_purchase_complete.tmpl
@@ -5,4 +5,58 @@ business. Please feel free to contact us at support@cyverse.org if you have any 
 
 <p>Your transaction ID is <strong>{{.TransactionId}}</strong>, your PO number is <strong>{{.PoNumber}}</strong>.</p>
 
+{{if .SubscriptionLevel}}
+<p>Your ordered subscription tier is <b>{{.SubscriptionLevel}}</b> for <b>{{.SubscriptionPeriod}}</b></p>
+<table>
+    <tbody>
+        <tr>
+            <th>Price</th>
+            <td>{{.SubscriptionPrice}}</td>
+        </tr>
+        <tr>
+            <th>Start Date</th>
+            <td>{{.SubscriptionStartDate}}</td>
+        </tr>
+        <tr>
+            <th>End Date</th>
+            <td>{{.SubscriptionEndDate}}</td>
+        </tr>
+        <tr>
+            <th>Quotas</th>
+            <td></td>
+        </tr>
+        {{range .SubscriptionQuotas}}
+        <tr>
+            <td></td>
+            <td>{{.}}</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{- end}}
+
+{{if .Addons}}
+<p><b>Ordered Add-ons</b></p>
+<table>
+    <thead>
+        <tr>
+            <th>Add-on</th>
+            <th>Quantity</th>
+            <th>Unit Price</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{range .Addons}}
+        <tr>
+            <td>{{.Name}}</td>
+            <td>{{.Quantity}}</td>
+            <td>{{.Price}}</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{- end}}
+
+<p><b>Order Total: {{.Amount}}</b></p>
+
 {{ template "footer" . }}

--- a/templates/html/subscription_purchase_complete.tmpl
+++ b/templates/html/subscription_purchase_complete.tmpl
@@ -5,6 +5,18 @@ business. Please feel free to contact us at support@cyverse.org if you have any 
 
 <p>Your transaction ID is <strong>{{.TransactionId}}</strong>, your PO number is <strong>{{.PoNumber}}</strong>.</p>
 
+<p>
+    Payed with {{.CardType}} ending in {{.CardNumberEnding}}<br />
+    Expires {{.CardExpiration}}
+</p>
+
+<p>
+    Billed to<br />
+    <b>{{.BillToName}}</b><br />
+    {{.BillToCompany}}<br />
+    {{.BillToAddress}}<br />
+</p>
+
 {{if .SubscriptionLevel}}
 <p>Your ordered subscription tier is <b>{{.SubscriptionLevel}}</b> for <b>{{.SubscriptionPeriod}}</b></p>
 <table>


### PR DESCRIPTION
This PR will update the subscription purchase template with additional info, such as the items ordered with prices and payment info.

The resulting email will look something like this (but with CyVerse / DE headers and footers):
<img width="990" height="580" alt="Subscription Purchase Email" src="https://github.com/user-attachments/assets/b3ebb17d-2008-4825-a28b-a0e71d19b1db" />
