### PR TITLE
CORE-2070 Add support for emailing attachments

### DIFF
--- a/api.go
+++ b/api.go
@@ -56,13 +56,14 @@ func (a *API) EmailRequestHandler(w http.ResponseWriter, r *http.Request) {
 					mimeType = HTML_MIME_TYPE
 				}
 				formattedReq := &FormattedEmailRequest{
-					To:       []string{toAddr},
-					Cc:       emailReq.Cc,
-					Bcc:      emailReq.Bcc,
-					From:     emailReq.FromAddr,
-					Subject:  emailReq.Subject,
-					MIMEType: mimeType,
-					Body:     formattedMsg.String(),
+					To:          []string{toAddr},
+					Cc:          emailReq.Cc,
+					Bcc:         emailReq.Bcc,
+					From:        emailReq.FromAddr,
+					Subject:     emailReq.Subject,
+					Attachments: emailReq.Attachments,
+					MIMEType:    mimeType,
+					Body:        formattedMsg.String(),
 				}
 				err := a.emailClient.Send(ctx, formattedReq)
 				if err != nil {

--- a/formatMessage.go
+++ b/formatMessage.go
@@ -18,13 +18,17 @@ import (
 
 // email request received
 type EmailRequest struct {
-	FromAddr string
-	To       string
-	Cc       []string
-	Bcc      []string
-	Template string
-	Subject  string
-	Values   json.RawMessage
+	FromAddr    string
+	To          string
+	Cc          []string
+	Bcc         []string
+	Template    string
+	Subject     string
+	Attachments []struct {
+		Filename string
+		Data     string // Base64-encoded file data
+	}
+	Values json.RawMessage
 }
 
 type Templater interface {


### PR DESCRIPTION
This PR will add support for emailing attachments, when the JSON request contains an `attachments` array, containing objects with a `filename` field and a `data` field, both strings, but the `data` is base64 encoded:
`"attachments": [{"filename": "test.txt", "data": "dGVzdGluZyB0ZXN0aW5nIDEyMyB0ZXN0Cg=="}]`